### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/src/components/pages/ListPage.tsx
+++ b/src/components/pages/ListPage.tsx
@@ -98,7 +98,7 @@ function ListPage() {
             >
                 <TileLayer
                     attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <UpdateMap />
                 {markers}

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -33,7 +33,7 @@ function MapView() {
             >
                 <TileLayer
                     attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <UpdateMap />
                 {markers}

--- a/src/components/pages/WebcamPage.tsx
+++ b/src/components/pages/WebcamPage.tsx
@@ -70,7 +70,7 @@ function ListPage() {
             >
                 <TileLayer
                     attribution='&amp;copy <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+                    url="https://tile.openstreetmap.org/{z}/{x}/{y}.png"
                 />
                 <UpdateMap />
                 {marker}


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one, see

https://github.com/openstreetmap/operations/issues/737