### PR TITLE
Change webcam icon to point in the direction the webcam is facing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
         "paren",
         "plusplus",
         "popperjs",
+        "rotatedmarker",
         "sonarjs",
         "wvdp",
         "youtu.be",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This project uses the OpenStreetMap Logo by Ken Vermette which is licensed under
 
 This project also uses the "Icons8 flat integrated webcam" icon from the Icons8 library. These icons are available under the [MIT](https://opensource.org/licenses/MIT) license and available at Wikimedia Commons ([link](https://commons.wikimedia.org/wiki/File:Icons8_flat_integrated_webcam.svg)).
 
+The black directional webcam icon was created by Wikipedia user Waffle5522 and kindly placed in the public domain.
+
 ## Todos
 
 - Preview webcams

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project uses the OpenStreetMap Logo by Ken Vermette which is licensed under
 
 This project also uses the "Icons8 flat integrated webcam" icon from the Icons8 library. These icons are available under the [MIT](https://opensource.org/licenses/MIT) license and available at Wikimedia Commons ([link](https://commons.wikimedia.org/wiki/File:Icons8_flat_integrated_webcam.svg)).
 
-The black directional webcam icon was created by Wikipedia user Waffle5522 and kindly placed in the public domain.
+The black directional webcam icon was created by Wikipedia user Waffle5522 and kindly placed in the [public domain (CC0)](https://creativecommons.org/publicdomain/zero/1.0/deed.en) and available at Wikimedia Commons ([link](https://commons.wikimedia.org/wiki/File:Video_camera_icon_svg.svg)).
 
 ## Todos
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@parcel/transformer-inline-string": "^2.10.3",
         "@parcel/transformer-sass": "^2.10.3",
         "@types/leaflet": "^1.9.8",
+        "@types/leaflet-rotatedmarker": "^0.2.5",
         "@types/lodash.chunk": "^4.2.9",
         "@types/lodash.set": "^4.3.9",
         "@types/node": "^20.9.2",
@@ -2464,6 +2465,15 @@
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/leaflet-rotatedmarker": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@types/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.5.tgz",
+      "integrity": "sha512-GaKK1bdQ6NYGkVdZj2cHe8Eu1BVf40Jhtmd8pZj5gQSJcTy5iTog0hsMIhf6QQDKnaEgrRJzm4OES6B9vxi4dw==",
+      "dev": true,
+      "dependencies": {
+        "@types/leaflet": "*"
       }
     },
     "node_modules/@types/lodash": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "bootstrap": "^5.3.2",
         "i18n-iso-countries": "^7.7.0",
         "leaflet": "^1.9.4",
+        "leaflet-rotatedmarker": "^0.2.0",
         "lodash.chunk": "^4.2.0",
         "lodash.set": "^4.3.2",
         "react": "^18.2.0",
@@ -6242,6 +6243,11 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+    },
+    "node_modules/leaflet-rotatedmarker": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/leaflet-rotatedmarker/-/leaflet-rotatedmarker-0.2.0.tgz",
+      "integrity": "sha512-yc97gxLXwbZa+Gk9VCcqI0CkvIBC9oNTTjFsHqq4EQvANrvaboib4UdeQLyTnEqDpaXHCqzwwVIDHtvz2mUiDg=="
     },
     "node_modules/levn": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "bootstrap": "^5.3.2",
     "i18n-iso-countries": "^7.7.0",
     "leaflet": "^1.9.4",
+    "leaflet-rotatedmarker": "^0.2.0",
     "lodash.chunk": "^4.2.0",
     "lodash.set": "^4.3.2",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@types/react-leaflet": "^3.0.0",
+    "@types/leaflet-rotatedmarker": "^0.2.5",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -15,8 +15,12 @@ function MapView() {
         if (webcam === null) {
             return null;
         }
+        let rotationAngle = 0;
+        if (webcam.direction !== undefined) {
+            rotationAngle = webcam.direction - 90; // unrotated icon points east
+        }
         return (
-            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={webcam.direction-90} rotationOrigin={"center center"}>
+            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={rotationAngle} rotationOrigin={"center center"}>
                 <Popup>
                     <PopupContent webcam={webcam} />
                 </Popup>

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -15,10 +15,7 @@ function MapView() {
         if (webcam === null) {
             return null;
         }
-        let rotationAngle = 0;
-        if (webcam.direction !== undefined) {
-            rotationAngle = webcam.direction - 90; // unrotated icon points east
-        }
+        const rotationAngle = webcam.direction === undefined ? 0 : webcam.direction - 90
         return (
             <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={rotationAngle} rotationOrigin={'center center'}>
                 <Popup>

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -15,7 +15,7 @@ function MapView() {
         if (webcam === null) {
             return null;
         }
-        const rotationAngle = webcam.direction === undefined ? 0 : webcam.direction - 90
+        const rotationAngle = webcam.direction === undefined ? 0 : webcam.direction - 90;
         return (
             <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={rotationAngle} rotationOrigin={'center center'}>
                 <Popup>

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
-import "leaflet-rotatedmarker";
+import 'leaflet-rotatedmarker';
 
 import MarkerIcon from '../parts/MarkerIcon';
 
@@ -20,7 +20,7 @@ function MapView() {
             rotationAngle = webcam.direction - 90; // unrotated icon points east
         }
         return (
-            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={rotationAngle} rotationOrigin={"center center"}>
+            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={rotationAngle} rotationOrigin={'center center'}>
                 <Popup>
                     <PopupContent webcam={webcam} />
                 </Popup>

--- a/src/components/pages/MapView.tsx
+++ b/src/components/pages/MapView.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { MapContainer, Marker, Popup, TileLayer } from 'react-leaflet';
+import "leaflet-rotatedmarker";
 
 import MarkerIcon from '../parts/MarkerIcon';
 
@@ -15,7 +16,7 @@ function MapView() {
             return null;
         }
         return (
-            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon}>
+            <Marker key={webcam.osmID} position={[webcam.lat, webcam.lon]} icon={MarkerIcon} rotationAngle={webcam.direction-90} rotationOrigin={"center center"}>
                 <Popup>
                     <PopupContent webcam={webcam} />
                 </Popup>

--- a/src/components/parts/MarkerIcon.tsx
+++ b/src/components/parts/MarkerIcon.tsx
@@ -1,7 +1,7 @@
 import {icon} from 'leaflet';
 
 // @ts-expect-error svg files are not compatible with typescript
-import webcamIcon from 'url:../../static/icon.svg';
+import webcamIcon from 'url:../../static/camera.svg';
 
 const iconHeight = 50;
 const iconWidth = 32;

--- a/src/static/camera.svg
+++ b/src/static/camera.svg
@@ -1,16 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="579.625" height="290.939" viewBox="0 0 579.62501 290.939" id="svg2" version="1.1" inkscape:version="0.91 r13725" sodipodi:docname="camera.svg"><script xmlns="" id="__gaOptOutExtension"/>
-  <title id="title4172">Camera Icon</title>
-  <defs id="defs4"/>
-  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="0.98994949" inkscape:cx="335.71089" inkscape:cy="206.70163" inkscape:document-units="px" inkscape:current-layer="g4147" showgrid="false" units="px" inkscape:window-width="1366" inkscape:window-height="705" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1"/>
-  <metadata id="metadata7">
+
+<svg:svg
+   width="579.625"
+   height="290.939"
+   viewBox="0 0 579.62501 290.939"
+   id="svg2"
+   version="1.1"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="camera.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <script
+     id="__gaOptOutExtension" />
+  <svg:title
+     id="title4172">Camera Icon</svg:title>
+  <svg:defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="349.28572"
+     inkscape:cy="169.64286"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4147"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1367"
+     inkscape:window-x="3840"
+     inkscape:window-y="360"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="0" />
+  <svg:metadata
+     id="metadata7">
     <rdf:RDF>
-      <cc:Work rdf:about="">
+      <cc:Work
+         rdf:about="">
         <dc:format>image/svg+xml</dc:format>
-        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
         <dc:title>Camera Icon</dc:title>
-        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
         <dc:date>05/02/2019</dc:date>
         <dc:creator>
           <cc:Agent>
@@ -18,17 +59,39 @@
           </cc:Agent>
         </dc:creator>
       </cc:Work>
-      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
-        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
-        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
       </cc:License>
     </rdf:RDF>
-  </metadata>
-  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(0,-761.42316)">
-    <g id="g4147" transform="translate(-154.25129,619.5272)">
-      <rect ry="45.488846" y="142.79245" x="154.68155" height="289.1395" width="382.58539" id="rect4136" style="opacity:1;fill:#000000;fill-opacity:1;stroke:#e6c988;stroke-width:0.86051887;stroke-opacity:1"/>
-      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="rect4142" d="m 554.25129,242.36795 178.94419,-99.31949 0,288.62748 -178.94419,-99.31949 z" style="opacity:1;fill:#000000;fill-opacity:1;stroke:#e6c988;stroke-width:1.3624723;stroke-opacity:1"/>
-    </g>
-  </g>
-</svg>
+  </svg:metadata>
+  <svg:g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-761.42316)">
+    <svg:g
+       id="g4147"
+       transform="translate(-154.25129,619.5272)">
+      <svg:rect
+         ry="45.488846"
+         y="142.79245"
+         x="154.68155"
+         height="289.1395"
+         width="382.58539"
+         id="rect4136"
+         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.86051887;stroke-opacity:1" />
+      <svg:path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4142"
+         d="m 554.25129,242.36795 178.94419,-99.31949 0,288.62748 -178.94419,-99.31949 z"
+         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.3624723;stroke-opacity:1" />
+    </svg:g>
+  </svg:g>
+</svg:svg>

--- a/src/static/camera.svg
+++ b/src/static/camera.svg
@@ -1,82 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg:svg
    width="579.625"
    height="290.939"
    viewBox="0 0 579.62501 290.939"
-   id="svg2"
    version="1.1"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   sodipodi:docname="camera.svg"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <script
-     id="__gaOptOutExtension" />
-  <svg:title
-     id="title4172">Camera Icon</svg:title>
-  <svg:defs
-     id="defs4" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="2.8"
-     inkscape:cx="349.28572"
-     inkscape:cy="169.64286"
-     inkscape:document-units="px"
-     inkscape:current-layer="g4147"
-     showgrid="false"
-     units="px"
-     inkscape:window-width="2560"
-     inkscape:window-height="1367"
-     inkscape:window-x="3840"
-     inkscape:window-y="360"
-     inkscape:window-maximized="1"
-     inkscape:pagecheckerboard="0" />
-  <svg:metadata
-     id="metadata7">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title>Camera Icon</dc:title>
-        <cc:license
-           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
-        <dc:date>05/02/2019</dc:date>
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>Waffle552</dc:title>
-          </cc:Agent>
-        </dc:creator>
-      </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Reproduction" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#Distribution" />
-        <cc:permits
-           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
-      </cc:License>
-    </rdf:RDF>
-  </svg:metadata>
+  <svg:title>Camera Icon</svg:title>
   <svg:g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1"
      transform="translate(0,-761.42316)">
     <svg:g
-       id="g4147"
        transform="translate(-154.25129,619.5272)">
       <svg:rect
          ry="45.488846"
@@ -84,12 +19,8 @@
          x="154.68155"
          height="289.1395"
          width="382.58539"
-         id="rect4136"
          style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.86051887;stroke-opacity:1" />
       <svg:path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="rect4142"
          d="m 554.25129,242.36795 178.94419,-99.31949 0,288.62748 -178.94419,-99.31949 z"
          style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.3624723;stroke-opacity:1" />
     </svg:g>

--- a/src/static/camera.svg
+++ b/src/static/camera.svg
@@ -1,28 +1,94 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg:svg
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="579.625"
    height="290.939"
    viewBox="0 0 579.62501 290.939"
+   id="svg2"
    version="1.1"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <svg:title>Camera Icon</svg:title>
-  <svg:g
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="camera.svg">
+  <title
+     id="title4172">Camera Icon</title>
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="335.71089"
+     inkscape:cy="204.68132"
+     inkscape:document-units="px"
+     inkscape:current-layer="g4147"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="2560"
+     inkscape:window-height="1361"
+     inkscape:window-x="-9"
+     inkscape:window-y="1271"
+     inkscape:window-maximized="1"
+     inkscape:document-rotation="0" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Camera Icon</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/" />
+        <dc:date>05/02/2019</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Waffle552</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
      transform="translate(0,-761.42316)">
-    <svg:g
+    <g
+       id="g4147"
        transform="translate(-154.25129,619.5272)">
-      <svg:rect
+      <rect
          ry="45.488846"
          y="142.79245"
          x="154.68155"
          height="289.1395"
          width="382.58539"
-         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.86051887;stroke-opacity:1" />
-      <svg:path
-         d="m 554.25129,242.36795 178.94419,-99.31949 0,288.62748 -178.94419,-99.31949 z"
-         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.3624723;stroke-opacity:1" />
-    </svg:g>
-  </svg:g>
-</svg:svg>
+         id="rect4136"
+         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.860519;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="rect4142"
+         d="M 554.25129,242.36795 733.19548,143.04846 V 431.67594 L 554.25129,332.35645 Z"
+         style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.36247;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/src/static/camera.svg
+++ b/src/static/camera.svg
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="579.625" height="290.939" viewBox="0 0 579.62501 290.939" id="svg2" version="1.1" inkscape:version="0.91 r13725" sodipodi:docname="camera.svg"><script xmlns="" id="__gaOptOutExtension"/>
+  <title id="title4172">Camera Icon</title>
+  <defs id="defs4"/>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="0.98994949" inkscape:cx="335.71089" inkscape:cy="206.70163" inkscape:document-units="px" inkscape:current-layer="g4147" showgrid="false" units="px" inkscape:window-width="1366" inkscape:window-height="705" inkscape:window-x="0" inkscape:window-y="0" inkscape:window-maximized="1"/>
+  <metadata id="metadata7">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title>Camera Icon</dc:title>
+        <cc:license rdf:resource="http://creativecommons.org/publicdomain/zero/1.0/"/>
+        <dc:date>05/02/2019</dc:date>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Waffle552</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License rdf:about="http://creativecommons.org/publicdomain/zero/1.0/">
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Reproduction"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#Distribution"/>
+        <cc:permits rdf:resource="http://creativecommons.org/ns#DerivativeWorks"/>
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(0,-761.42316)">
+    <g id="g4147" transform="translate(-154.25129,619.5272)">
+      <rect ry="45.488846" y="142.79245" x="154.68155" height="289.1395" width="382.58539" id="rect4136" style="opacity:1;fill:#000000;fill-opacity:1;stroke:#e6c988;stroke-width:0.86051887;stroke-opacity:1"/>
+      <path sodipodi:nodetypes="ccccc" inkscape:connector-curvature="0" id="rect4142" d="m 554.25129,242.36795 178.94419,-99.31949 0,288.62748 -178.94419,-99.31949 z" style="opacity:1;fill:#000000;fill-opacity:1;stroke:#e6c988;stroke-width:1.3624723;stroke-opacity:1"/>
+    </g>
+  </g>
+</svg>

--- a/src/types/webcam.ts
+++ b/src/types/webcam.ts
@@ -1,7 +1,7 @@
 export interface Webcam {
     lat: number;
     lon: number;
-    direction: number;
+    direction?: number; // direction the camera is facing, in degrees
 
     osmID: number;
     user: string;

--- a/src/types/webcam.ts
+++ b/src/types/webcam.ts
@@ -1,6 +1,7 @@
 export interface Webcam {
     lat: number;
     lon: number;
+    direction: number;
 
     osmID: number;
     user: string;

--- a/utils/collect.ts
+++ b/utils/collect.ts
@@ -139,9 +139,9 @@ const queryNominatim = async (lat: number, lon: number): Promise<NominatimRespon
 
         const nominatim = await queryNominatim(r.lat, r.lon);
 
-        let direction = Number(r.tags["camera:direction"]);
+        let direction = Number(r.tags['camera:direction']);
         if (Number.isNaN(direction)) {
-            direction = Number(r.tags["direction"]);
+            direction = Number(r.tags.direction);
         }
         webcams.push({
             lat: r.lat,

--- a/utils/collect.ts
+++ b/utils/collect.ts
@@ -139,14 +139,14 @@ const queryNominatim = async (lat: number, lon: number): Promise<NominatimRespon
 
         const nominatim = await queryNominatim(r.lat, r.lon);
 
-        let direction = parseInt(r.tags["camera:direction"]);
+        let direction = Number(r.tags["camera:direction"]);
         if (Number.isNaN(direction)) {
-            direction = parseInt(r.tags["direction"]);
+            direction = Number(r.tags["direction"]);
         }
         webcams.push({
             lat: r.lat,
             lon: r.lon,
-            direction: Number.isNaN(direction) ? 90 : direction, // point east by default
+            direction: Number.isNaN(direction) ? undefined : direction,
 
             osmID: r.id,
             user: r.user,

--- a/utils/collect.ts
+++ b/utils/collect.ts
@@ -139,14 +139,17 @@ const queryNominatim = async (lat: number, lon: number): Promise<NominatimRespon
 
         const nominatim = await queryNominatim(r.lat, r.lon);
 
-        let direction = Number(r.tags['camera:direction']);
-        if (Number.isNaN(direction)) {
-            direction = Number(r.tags.direction);
-        }
+        const direction = [
+            r.tags['camera:direction'],
+            r.tags.direction
+        ]
+            .map(Number)
+            .find((d) => !Number.isNaN(d));
+
         webcams.push({
             lat: r.lat,
             lon: r.lon,
-            direction: Number.isNaN(direction) ? undefined : direction,
+            direction,
 
             osmID: r.id,
             user: r.user,

--- a/utils/collect.ts
+++ b/utils/collect.ts
@@ -139,9 +139,14 @@ const queryNominatim = async (lat: number, lon: number): Promise<NominatimRespon
 
         const nominatim = await queryNominatim(r.lat, r.lon);
 
+        let direction = parseInt(r.tags["camera:direction"]);
+        if (Number.isNaN(direction)) {
+            direction = parseInt(r.tags["direction"]);
+        }
         webcams.push({
             lat: r.lat,
             lon: r.lon,
+            direction: Number.isNaN(direction) ? 90 : direction, // point east by default
 
             osmID: r.id,
             user: r.user,


### PR DESCRIPTION
I think it's very useful to see on the map already what direction a webcam is facing, and this data is often available.
To this end I changed the icon to be more directional (svg taken from https://de.wikipedia.org/wiki/Datei:Video_camera_icon_svg.svg) and rotated it appropriately.